### PR TITLE
Remove workflow_dispatch from build containers workflow

### DIFF
--- a/.github/workflows/03-build-containers.yml
+++ b/.github/workflows/03-build-containers.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     types: [closed]
     branches: [ desafio-nivel-3 ]
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Removed workflow_dispatch event from the build containers workflow.